### PR TITLE
corrected javadoc

### DIFF
--- a/codenvy-contribution-vcs/src/main/java/com/codenvy/plugin/contribution/vcs/client/hosting/NoVcsHostingServiceImplementationException.java
+++ b/codenvy-contribution-vcs/src/main/java/com/codenvy/plugin/contribution/vcs/client/hosting/NoVcsHostingServiceImplementationException.java
@@ -21,7 +21,7 @@ public class NoVcsHostingServiceImplementationException extends Exception {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs an instance of {@link com.codenvy.plugin.contribution.vcs.client.hosting.VcsHostingService}.
+     * Constructs an instance of {@link com.codenvy.plugin.contribution.vcs.client.hosting.NoVcsHostingServiceImplementationException}.
      */
     public NoVcsHostingServiceImplementationException() {
         super("No implementation of the VcsHostingService for the current project");


### PR DESCRIPTION
the constructor’s javadoc must have been copypasted (or whatever).
